### PR TITLE
fix, descend into local libltdl/ subdir if --with-included-libltdl is pa...

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,11 @@ LC_ALL = C
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src sample doc test
+SUBDIRS =
+if DESCEND_LIBLTDL
+SUBDIRS += libltdl
+endif  DESCEND_LIBLTDL
+SUBDIRS += src sample doc test
 
 doc_DATA =
 doc_DATA += README

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,7 @@ LT_SYS_SYMBOL_USCORE
 LT_FUNC_DLSYM_USCORE
 LT_CONFIG_LTDL_DIR([libltdl], [recursive])
 LTDL_INIT
+AM_CONDITIONAL([DESCEND_LIBLTDL], [test "${with_included_ltdl}" = "yes"])
 
 PKG_CHECK_MODULES([libxml2], [libxml-2.0 >= 2.7])
 PKG_CHECK_MODULES([twsapi], [twsapi >= 0.4.0],


### PR DESCRIPTION
...ssed on to configure

This will facilitate builds on boxen without libltdl-dev(el) installed.

Signed-off-by: Sebastian Freundt freundt@fresse.org
